### PR TITLE
Parallel chunk getitems

### DIFF
--- a/zarr/core.py
+++ b/zarr/core.py
@@ -64,7 +64,29 @@ from zarr.util import (
     ensure_ndarray_like,
 )
 
+
+from joblib import Parallel, delayed
+
 __all__ = ["Array"]
+
+# Number of ckeys required to trigger parallelism in _chunk_getitems
+PARALLEL_THRESHOLD=12
+# Number of chunks to batch per parallel worker task
+PARALLEL_BATCH_SIZE=8
+def parallel_io_method(instance, c_key, c_select, out_sel, drop_axes, my_out):
+    try:
+        cdata = instance.chunk_store[c_key]
+        chunk = instance._decode_chunk(cdata)
+        tmp = chunk[c_select]
+        if drop_axes:
+            tmp = np.squeeze(tmp, axis=drop_axes)
+        my_out[out_sel] = tmp
+
+    except Exception:
+        # If the read/parse failed, the file name will be in the exception.
+        # If the key is not present, there is no more info to log.
+        logger.exception("Error reading chunk %s", c_key)
+        my_out[out_sel] = instance._fill_value
 
 
 # noinspection PyUnresolvedReferences
@@ -2169,32 +2191,27 @@ class Array:
             cdatas = {key: value for key, value in zip(ckeys, values) if value is not None}
 
 
-        elif "GRIBCodec" in list(map(lambda x: str(x.__class__.__name__), self.filters or [])) and len(ckeys) > 1:
+        elif "GRIBCodec" in list(map(lambda x: str(x.__class__.__name__), self.filters or [])):
             # Start parallel grib hack
             # Make this really specific to GRIBCodec for now - we can make this more general later?
-            from joblib import Parallel, delayed
+            # Can we pass parameters for the heuristic behavior thresholds? Use module constants for now
+            key_count = len(ckeys)
+            if key_count <= PARALLEL_THRESHOLD:
+                logger.info("Chunk Count %s <= Parallel Threshold %s: Using Serial Chunk GetItems", key_count, PARALLEL_THRESHOLD)
+                for ckey, chunk_select, out_select in zip(ckeys, lchunk_selection, lout_selection):
+                    parallel_io_method(self, ckey, chunk_select, out_select, drop_axes, out)
+                return
 
-            def parallel_io_method(instance, c_key, c_select, out_sel, my_out):
-                try:
-                    cdata = instance.chunk_store[c_key]
-                    chunk = instance._decode_chunk(cdata)
-                    tmp = chunk[c_select]
-                    if drop_axes:
-                        tmp = np.squeeze(tmp, axis=drop_axes)
-                    my_out[out_sel] = tmp
-
-                except Exception:
-                    # TODO: get more context from the mapper about what chunk failed!
-                    logger.exception("Error reading chunk %s", c_key)
-                    my_out[out_sel] = instance._fill_value
-
+            logger.info("Chunk Count %s greater than Parallel Threshold %s: Using Parallel Chunk GetItems with Parallel Batch Size: %s", key_count, PARALLEL_THRESHOLD, PARALLEL_BATCH_SIZE)
+            # Explicitly use /dev/shm to ensure we are working in memory
             with tempfile.NamedTemporaryFile(mode="w+b", prefix="zarr_memmap", dir="/dev/shm") as f:
-                logger.warning("Creating memmap array of shape %s - this could oom", out.shape)
+                logger.warning("Creating memmap array of shape %s, size %s - this could oom or exceed the size of /dev/shm", out.shape, out.nbytes)
                 output = np.memmap(f, dtype=out.dtype, shape=out.shape, mode='w+')
-
+                 
                 # Just setting mmap_mode to w+ doesn't seem to copy the data back to out...
-                Parallel()(
-                    delayed(parallel_io_method)(self, ckey, chunk_select, out_select, output)
+                # Hard to know batch_size without n_jobs. Use a const here too
+                Parallel(pre_dispatch="2*n_jobs", batch_size=PARALLEL_BATCH_SIZE)(
+                    delayed(parallel_io_method)(self, ckey, chunk_select, out_select, drop_axes, output)
                     for ckey, chunk_select, out_select in zip(ckeys, lchunk_selection, lout_selection)
                 )
 

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -2169,7 +2169,7 @@ class Array:
             cdatas = {key: value for key, value in zip(ckeys, values) if value is not None}
 
 
-        elif "GRIBCodec" in list(map(lambda x: str(x.__class__.__name__), self.filters or [])):
+        elif "GRIBCodec" in list(map(lambda x: str(x.__class__.__name__), self.filters or [])) and len(ckeys) > 1:
             # Start parallel grib hack
             # Make this really specific to GRIBCodec for now - we can make this more general later?
             from joblib import Parallel, delayed

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -2188,7 +2188,7 @@ class Array:
                     logger.exception("Error reading chunk %s", c_key)
                     my_out[out_sel] = instance._fill_value
 
-            with tempfile.NamedTemporaryFile(mode="w+b", prefix="zarr_memmap") as f:
+            with tempfile.NamedTemporaryFile(mode="w+b", prefix="zarr_memmap", dir="/dev/shm") as f:
                 logger.warning("Creating memmap array of shape %s - this could oom", out.shape)
                 output = np.memmap(f, dtype=out.dtype, shape=out.shape, mode='w+')
 


### PR DESCRIPTION
# Prototype Parallel get_chunkitems

This is a draft implementation that chooses a particular parallel framework suitable for my application. This is not a generalized solution that could be merged into zarr... but it does show the potential of allowing parallelism at this critical point in zarr core.


TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
